### PR TITLE
Wait for each comment to be deleted before continuing.

### DIFF
--- a/chrome-ext/script.js
+++ b/chrome-ext/script.js
@@ -1,59 +1,100 @@
-// try 0, then try increasing values. this is delay between comment deletions
-var DELAY = 0;
+// How long to wait for more comments to stream in after scrolling to the bottom.
+const LOAD_MORE_DELAY = 5000;
 
-// if script ends but yt has more comments loading then increase this pause value.
-// this provides 1 retry attempt between list updates. useful for slow cpu/network.
-// (electronoob: 800 was the ideal value for my machine)
-var PAUSE = 5000;
+var deletedTotal = 0;
+// Did we delete any comments last time we autoscrolled?
+var deletedLastRefresh = 0;
+// How many comments did we delete since autoscrolling?
+var deletedThisRefresh = 0;
+// If we didn't delete any comments this time, and we didn't delete any last time,
+// there are probably no more comments to load and the script will end.
 
-var myList = document.getElementsByClassName("YxbmAc");
+// Reset each time we click a delete button; used to continue making progress even if
+// we miss a DOM update for some reason.
+var pendingDeleteTimer = null;
+const DELETE_TIMEOUT = 5000;
+var deletionsTimedOut = 0;
+// If pendingDeleteTimer is allowed to tick this many times the script will end
+// because comments are not being removed from the list after being clicked.
+const MAX_TIMEOUTS_BEFORE_QUITTING = 5;
 
-// scroll to the bottom of the page
-function autoScroll () {
-  window.scrollTo({ left: 0, top: document.body.scrollHeight, behavior: "smooth" });
-}
+// Observe this for changes to detect when the comment is successfully deleted.
+// The comment is hidden on click, but the list is not mutated until the backend
+// returns success.
+const commentListElement = document.body.getElementsByClassName("ez10qf")[0];
+var deletedObserver = new MutationObserver((mutations, observer) => {
+  ++deletedThisRefresh;
+  ++deletedTotal;
+  recursivelyClickDelete();
+});
 
-// check for available comments
-function commentsAvailable2 () {
-  var m = document.getElementsByClassName("YxbmAc");
-  if(m.length > 0){
-    console.log('erasure: %s comments are available.', m.length);
-    return true;
+
+function loadMoreComments() {
+  if (!deletedThisRefresh && !deletedLastRefresh) {
+    console.log("erasure: no more comments to delete. We're done!");
+    return;
   }
-  return false;
+
+  deletedLastRefresh = deletedThisRefresh;
+  deletedThisRefresh = 0;
+
+  console.log(
+    "erasure: scrolling to bottom and waiting %d ms for more comments to load", LOAD_MORE_DELAY
+  );
+
+  // Scroll to the bottom of the page
+  window.scrollTo({ left: 0, top: document.body.scrollHeight, behavior: "smooth" });
+  // Wait for more comments to stream in
+  setTimeout(recursivelyClickDelete, LOAD_MORE_DELAY);
 }
 
 /* This function clicks the delete button for both regular and 
    non-G-suite account users. */
-function deleteClick(element, callback1){
-  try{ 
-    element.querySelectorAll(".VfPpkd-rymPhb-pZXsl")[1].click();
-    setTimeout(callback1, DELAY);
+function recursivelyClickDelete() {
+  // Don't respond to changes unless we just clicked a button
+  deletedObserver.disconnect();
+  // Stop waiting for the last click to fail and just continue with the next one
+  if (pendingDeleteTimer) {
+    clearTimeout(pendingDeleteTimer);
   }
-  catch{
-    element.querySelectorAll(".VfPpkd-Bz112c-LgbsSe")[0].click();
-    setTimeout(callback1, DELAY);
-  }
-}
 
-/* Main function */
-function main(i) {
-  if(commentsAvailable2()) {
-    deleteClick(myList[i], () => {
-      ++i;
-      if (i < myList.length) {
-        main(i);
-      }else {
-        console.log("erasure: attempting to retry in %s ms",PAUSE);
-        autoScroll();
-        setTimeout(()=>{
-          main(0);
-        },PAUSE);
+  var buttons = document.body.querySelectorAll(".YxbmAc .VfPpkd-rymPhb-pZXsl");
+  if (!buttons || !buttons.length) {
+    buttons = document.body.querySelectorAll(".YxbmAc .VfPpkd-Bz112c-LgbsSe");
+  }
+  if (!buttons || !buttons.length) {
+    console.log(
+      "erasure: deleted %d %s (%d total); attempting to load more", 
+      deletedThisRefresh, (deletedThisRefresh == 1 ? "comment" : "comments"),
+      deletedTotal
+    );
+    loadMoreComments();
+    return;
+  }
+
+  try {
+    let btn = buttons[0];
+    if (!btn || !btn.click) {
+      throw "can't find button with click()";
+    }
+    
+    btn.click();
+    deletedObserver.observe(commentListElement, { subtree: true, childList: true });
+
+    pendingDeleteTimer = setTimeout(() => {
+      if (++deletionsTimedOut >= MAX_TIMEOUTS_BEFORE_QUITTING) {
+        console.error("erasure: timed out waiting for %d comments to be deleted. Quitting...");
+        return;
       }
-    });
-  } else {
-    console.log("erasure: there are no comments, exiting.");
+      console.warn("erasure: timed out waiting for comment to be removed after clicking delete.");
+      ++deletionsTimedOut;
+      recursivelyClickDelete();
+    }, DELETE_TIMEOUT);
+
+  } catch (ex) {
+    console.warn("erasure: exception clicking delete button: " + ex);
   }
 }
 
-main(0);
+// Entrypoint
+recursivelyClickDelete();

--- a/chrome-ext/script.js
+++ b/chrome-ext/script.js
@@ -77,10 +77,13 @@ function recursivelyClickDelete() {
     if (!btn || !btn.click) {
       throw "can't find button with click()";
     }
-    
-    btn.click();
+    // Watch the list for the comment to be removed so we can continue deleting.
     deletedObserver.observe(commentListElement, { subtree: true, childList: true });
+    btn.click();
 
+    // Start waiting to continue even if we don't see the list update.
+    // I don't know under what circumstances we'd hit this, but I'd rather not be surprised
+    // by a missed event causing the extension to quietly fail.
     pendingDeleteTimer = setTimeout(() => {
       if (++deletionsTimedOut >= MAX_TIMEOUTS_BEFORE_QUITTING) {
         console.error("erasure: timed out waiting for %d comments to be deleted. Quitting...");


### PR DESCRIPTION
As available on the app store, the extension doesn't delete any comments for me. They're hidden and I see the popup in the corner, but when I refresh they all come back.

I tried adjusting the delays and batching, but it seems the only way I can reliably see every comment deleted is to wait for each one before continuing.

Here I watch the comment list for changes to detect when the deletion was successful. This slows the process down by a huge amount, but it works every time.